### PR TITLE
Closes #6 POP paging

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -6,8 +6,9 @@ target 'Sunrise' do
     pod 'ReactiveCocoa', '~> 4.1'
     pod 'ObjectMapper', '~> 1.3'
     pod 'IQKeyboardManagerSwift', '4.0.3'
-    pod 'IQDropDownTextField'
     pod 'SDWebImage', '~> 3.7'
+    pod 'IQDropDownTextField'
+    pod 'SVProgressHUD'
 end
 
 def testing_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,6 +22,7 @@ PODS:
   - SDWebImage (3.7.6):
     - SDWebImage/Core (= 3.7.6)
   - SDWebImage/Core (3.7.6)
+  - SVProgressHUD (2.0.3)
 
 DEPENDENCIES:
   - Commercetools (~> 0.1)
@@ -32,6 +33,7 @@ DEPENDENCIES:
   - Quick
   - ReactiveCocoa (~> 4.1)
   - SDWebImage (~> 3.7)
+  - SVProgressHUD
 
 SPEC CHECKSUMS:
   Alamofire: c19a627cefd6a95f840401c49ab1f124e07f54ee
@@ -44,5 +46,6 @@ SPEC CHECKSUMS:
   ReactiveCocoa: d70004d7a366a7b8e87e60ce2347182c77701949
   Result: 9e75e1111c774c6ac594e14907b15057053a7959
   SDWebImage: c325cf02c30337336b95beff20a13df489ec0ec9
+  SVProgressHUD: b0830714205bea1317ea1a2ebc71e5633af334d4
 
 COCOAPODS: 0.39.0

--- a/Sunrise/Base.lproj/Main.storyboard
+++ b/Sunrise/Base.lproj/Main.storyboard
@@ -71,6 +71,14 @@
                                     <constraint firstAttribute="bottomMargin" secondItem="m8U-Js-RKL" secondAttribute="bottom" id="cyF-TT-74V"/>
                                     <constraint firstItem="m8U-Js-RKL" firstAttribute="top" secondItem="v0H-ge-AMn" secondAttribute="top" id="oWA-4D-KcE"/>
                                 </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
+                                        <integer key="value" value="1"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                        <color key="value" red="0.83921568627450982" green="0.83921568627450982" blue="0.83921568627450982" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
                                 <connections>
                                     <outlet property="oldPriceLabel" destination="waE-RF-s08" id="eXv-Ir-6mi"/>
                                     <outlet property="priceLabel" destination="GeO-pU-koa" id="u3p-Mb-bme"/>

--- a/Sunrise/Base.lproj/Main.storyboard
+++ b/Sunrise/Base.lproj/Main.storyboard
@@ -48,13 +48,13 @@
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="OldPrice" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="waE-RF-s08">
                                                             <rect key="frame" x="0.0" y="0.0" width="59" height="18"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Price" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GeO-pU-koa">
                                                             <rect key="frame" x="59" y="0.0" width="35" height="18"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                     </subviews>

--- a/Sunrise/Cells/ProductOverviewCell.swift
+++ b/Sunrise/Cells/ProductOverviewCell.swift
@@ -5,6 +5,13 @@
 import UIKit
 
 class ProductOverviewCell: UICollectionViewCell {
+    
+    @IBInspectable var borderColor: UIColor = UIColor.lightGrayColor()
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        layer.borderColor = borderColor.CGColor
+    }
 
     // MARK: - Outlets
 

--- a/Sunrise/ViewModels/ProductOverviewViewModel.swift
+++ b/Sunrise/ViewModels/ProductOverviewViewModel.swift
@@ -49,7 +49,7 @@ class ProductOverviewViewModel {
         nextPageSignal
         .observeNext { [weak self] in
             if let productCount = self?.products.count where productCount > 0 {
-                self?.queryForProductProjections(offset: UInt(productCount - 1))
+                self?.queryForProductProjections(offset: UInt(productCount))
             }
         }
     }


### PR DESCRIPTION
- Always fetch no more than 16 products (per request);
- If the query or search user selected contains more than 16 products, others will be loaded as the user reaches the end of the collection view;
- In case the user scrolls down slowly, we fire up the request for the next 16 products while he/she is on the 7th or 8th (approx half). That way, if I don't scroll down very fast, I'll never see a loading indicator.

@lauraluiz @cneijenhuis @sven-straubinger 
