### PR TITLE
Fix memory leak ContiguousArrayStorage<String>

### DIFF
--- a/Sunrise/ViewModels/ProductOverviewViewModel.swift
+++ b/Sunrise/ViewModels/ProductOverviewViewModel.swift
@@ -77,9 +77,9 @@ class ProductOverviewViewModel {
         guard let price = products[indexPath.row].mainVariantWithPrice?.independentPrice, value = price.value else { return "" }
 
         if let discounted = price.discounted?.value {
-            return "\(discounted)"
+            return String(discounted)
         } else {
-            return "\(value)"
+            return String(value)
         }
     }
 


### PR DESCRIPTION
There seems to be a bug in the core library of Swift causing a memory leak with interpolated strings, see screenshot:

<img width="1012" alt="mem-leak" src="https://cloud.githubusercontent.com/assets/1197899/15676568/08c14b08-2747-11e6-9c3b-c8ec32bc4392.png">

The fix is quite trivial, thus we should give it a go. Also see  [stackoverflow](http://stackoverflow.com/questions/36651407/contiguousarraystoragestring-leaks-while-uploading-new-image-why).
