### PR TITLE
Issues/#74 Handle reservation confirmation push notification

### DIFF
--- a/Sunrise.xcodeproj/project.pbxproj
+++ b/Sunrise.xcodeproj/project.pbxproj
@@ -553,6 +553,11 @@
 				TargetAttributes = {
 					21CDC4931CE91D9B009D2638 = {
 						CreatedOnToolsVersion = 7.3.1;
+						SystemCapabilities = {
+							com.apple.Push = {
+								enabled = 1;
+							};
+						};
 					};
 					21CDC4A91CE91D9B009D2638 = {
 						CreatedOnToolsVersion = 7.3.1;

--- a/Sunrise/AppDelegate.swift
+++ b/Sunrise/AppDelegate.swift
@@ -30,7 +30,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         IQKeyboardManager.sharedManager().enable = true
 
+        application.registerUserNotificationSettings(UIUserNotificationSettings(forTypes: [.Sound, .Alert, .Badge], categories: nil))
+        application.registerForRemoteNotifications()
+
+        if let notificationInfo = launchOptions?[UIApplicationLaunchOptionsRemoteNotificationKey] as? [NSObject : AnyObject] {
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(1 * Double(NSEC_PER_SEC))), dispatch_get_main_queue()) {
+                self.handlePushNotification(notificationInfo)
+            }
+        }
+
         return true
+    }
+
+    func application(application: UIApplication, didReceiveRemoteNotification userInfo: [NSObject : AnyObject]) {
+        handlePushNotification(userInfo)
+    }
+
+    private func handlePushNotification(notificationInfo: [NSObject : AnyObject]) {
+        if let reservationId = notificationInfo["reservation-id"] as? String {
+            AppRouting.showReservationWithId(reservationId)
+        }
     }
 
 }

--- a/Sunrise/Helpers/AppRouting.swift
+++ b/Sunrise/Helpers/AppRouting.swift
@@ -71,4 +71,16 @@ class AppRouting {
         homeNavigationController.popToRootViewControllerAnimated(true)
     }
 
+    /**
+        Switches to the account tab, and presents reservation overview view controller.
+    */
+    static func showReservationWithId(reservationId: String) {
+        guard let tabBarController = tabBarController, ordersNavigationController = tabBarController.viewControllers?[2] as? UINavigationController,
+                ordersViewController = ordersNavigationController.viewControllers.first as? OrdersViewController else { return }
+
+        tabBarController.selectedIndex = 2
+        ordersNavigationController.popToRootViewControllerAnimated(false)
+        ordersViewController.viewModel?.presentConfirmationForReservationWithId(reservationId)
+    }
+
 }

--- a/Sunrise/ViewControllers/OrdersViewController.swift
+++ b/Sunrise/ViewControllers/OrdersViewController.swift
@@ -94,6 +94,12 @@ class OrdersViewController: UIViewController {
             })
         })
 
+        viewModel.showReservationSignal
+        .observeOn(UIScheduler())
+        .observeNext({ [weak self] indexPath in
+            self?.performSegueWithIdentifier("reservationDetails", sender: indexPath)
+        })
+
         observeAlertMessageSignal(viewModel: viewModel)
 
         viewModel.refreshObserver.sendNext()


### PR DESCRIPTION
For the purpose of this feature, the actual reservation ID should be added to the notification payload in the following format:

```
{
   "aps":{
      "alert":"Your reservation is ready for pickup."
   },
   "reservation-id":"b826402a-8025-4908-968a-3010fb307fd9"
}
```

After integration with PushTech has been completed, we'll see where this can be fit from their backend, and make appropriate changes for the `joyride` branch.
