### PR TITLE
Closes #78 Reset app badge icon on each launch

### DIFF
--- a/Sunrise/AppDelegate.swift
+++ b/Sunrise/AppDelegate.swift
@@ -48,6 +48,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         PSHEngine.sharedInstance().setLocationAdquisition(.Always)
     }
 
+    func applicationDidBecomeActive(application: UIApplication) {
+        application.applicationIconBadgeNumber = 0
+    }
+
 }
 
 extension AppDelegate: PSHNotificationDelegate {


### PR DESCRIPTION
In order to workaround PT SDK bug, we reset app badge icon on each launch.
