### PR TITLE
Closes #81 Update channels to accommodate new custom type

### DIFF
--- a/Sunrise/Models/Channel/Channel.swift
+++ b/Sunrise/Models/Channel/Channel.swift
@@ -32,11 +32,8 @@ class Channel: Mappable {
         }
         return "-"
     }
-    var openLine1Info: String {
-        return details?.openLine1 ?? "-"
-    }
-    var openLine2Info: String {
-        return details?.openLine2 ?? "-"
+    var openingTimes: String {
+        return details?.openingTimes?.localizedString ?? "-"
     }
 
     required init?(_ map: Map) {}

--- a/Sunrise/Models/Channel/ChannelDetails.swift
+++ b/Sunrise/Models/Channel/ChannelDetails.swift
@@ -10,8 +10,8 @@ struct ChannelDetails: Mappable {
 
     var openingTimes: [String: String]?
     var imageUrl: String?
-    var latitude: Double?
-    var longitude: Double?
+    var latitude: String?
+    var longitude: String?
 
     init?(_ map: Map) {}
 

--- a/Sunrise/Models/Channel/ChannelDetails.swift
+++ b/Sunrise/Models/Channel/ChannelDetails.swift
@@ -8,18 +8,20 @@ struct ChannelDetails: Mappable {
 
     // MARK: - Properties
 
-    var openLine1: String?
-    var openLine2: String?
+    var openingTimes: [String: String]?
     var imageUrl: String?
+    var latitude: Double?
+    var longitude: Double?
 
     init?(_ map: Map) {}
 
     // MARK: - Mappable
 
     mutating func mapping(map: Map) {
-        openLine1        <- map["fields.openLine1"]
-        openLine2        <- map["fields.openLine2"]
+        openingTimes     <- map["fields.openingTimes"]
         imageUrl         <- map["fields.imageUrl"]
+        latitude         <- map["fields.latitude"]
+        longitude        <- map["fields.longitude"]
     }
 
 }

--- a/Sunrise/Storyboard/Account.storyboard
+++ b/Sunrise/Storyboard/Account.storyboard
@@ -79,7 +79,7 @@
                                                         <rect key="frame" x="0.0" y="80" width="564" height="54"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="eyv-UK-C5L" id="evC-HH-Sru">
-                                                            <rect key="frame" x="0.0" y="0.0" width="564" height="54"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="564" height="53.5"/>
                                                             <autoresizingMask key="autoresizingMask"/>
                                                             <subviews>
                                                                 <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f5M-dm-8OX">
@@ -252,7 +252,7 @@
                                                 <rect key="frame" x="0.0" y="28" width="584" height="185"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ADQ-GI-8yu" id="ICf-oM-gc5">
-                                                    <rect key="frame" x="0.0" y="0.0" width="584" height="185"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="584" height="184.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="6Nk-oP-7qE">
@@ -431,7 +431,7 @@
                                                 <rect key="frame" x="0.0" y="213" width="584" height="150"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Pgv-dz-kDJ" id="Nmf-50-cv9">
-                                                    <rect key="frame" x="0.0" y="0.0" width="584" height="150"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="584" height="149.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="kTz-rB-hCe">
@@ -662,19 +662,19 @@
                                                                     <constraint firstAttribute="height" constant="18" id="T0y-5Q-EQY"/>
                                                                 </constraints>
                                                             </stackView>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" misplaced="YES" text="Product name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iRM-mr-XQd">
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Product name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iRM-mr-XQd">
                                                                 <rect key="frame" x="0.0" y="329" width="548" height="0.0"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                                                 <color key="textColor" red="0.25098039215686274" green="0.28627450980392155" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tGX-jo-9rT">
+                                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tGX-jo-9rT">
                                                                 <rect key="frame" x="0.0" y="329" width="548" height="8"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="8" id="RJw-Dt-wgT"/>
                                                                 </constraints>
                                                             </stackView>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="I4T-qs-etJ">
+                                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="I4T-qs-etJ">
                                                                 <rect key="frame" x="0.0" y="337" width="548" height="54"/>
                                                                 <subviews>
                                                                     <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="t7O-Fm-1kA">
@@ -758,25 +758,25 @@
                                                                     </stackView>
                                                                 </subviews>
                                                             </stackView>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="t5X-cz-git">
+                                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="t5X-cz-git">
                                                                 <rect key="frame" x="0.0" y="391" width="548" height="8"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="8" id="CF5-oO-fJn"/>
                                                                 </constraints>
                                                             </stackView>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="752" misplaced="YES" text="PICKUP" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bma-Zs-qdZ">
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="752" text="PICKUP" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bma-Zs-qdZ">
                                                                 <rect key="frame" x="0.0" y="399" width="548" height="0.0"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                                 <color key="textColor" red="0.25098039215686274" green="0.28627450980392155" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bKb-av-zcp">
+                                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bKb-av-zcp">
                                                                 <rect key="frame" x="0.0" y="399" width="548" height="8"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="8" id="Lv7-ha-TLV"/>
                                                                 </constraints>
                                                             </stackView>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="xwu-Px-64m">
+                                                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="xwu-Px-64m">
                                                                 <rect key="frame" x="0.0" y="407" width="548" height="155"/>
                                                                 <subviews>
                                                                     <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" mapType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="c15-nx-2ji">
@@ -787,13 +787,13 @@
                                                                     </mapView>
                                                                 </subviews>
                                                             </stackView>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Zap-4o-jNk">
+                                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zap-4o-jNk">
                                                                 <rect key="frame" x="0.0" y="562" width="548" height="18"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="18" id="Ys4-2a-KSD"/>
                                                                 </constraints>
                                                             </stackView>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" misplaced="YES" text="Store Name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GKI-Tq-bbI">
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Store Name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GKI-Tq-bbI">
                                                                 <rect key="frame" x="0.0" y="580" width="548" height="0.0"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                                                 <color key="textColor" red="0.25098039215686274" green="0.28627450980392155" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
@@ -861,13 +861,13 @@
                                                                                     <constraint firstAttribute="height" constant="9" id="ZYa-4z-wqf"/>
                                                                                 </constraints>
                                                                             </stackView>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Mo. - Fr. 10.00am - 8..00pm" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="Ckx-Ug-c1f">
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Mo. - Fr. 10.00am - 8..00pm" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="Ckx-Ug-c1f">
                                                                                 <rect key="frame" x="0.0" y="49" width="420" height="17"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                                 <color key="textColor" red="0.52156862745098043" green="0.52156862745098043" blue="0.52156862745098043" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="Sa. 9.00a.m - 6.00pm" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="Znr-9f-KSv">
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="Znr-9f-KSv">
                                                                                 <rect key="frame" x="0.0" y="66" width="420" height="22"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                                 <color key="textColor" red="0.52156862745098043" green="0.52156862745098043" blue="0.52156862745098043" alpha="1" colorSpace="calibratedRGB"/>

--- a/Sunrise/Storyboard/ProductDetails.storyboard
+++ b/Sunrise/Storyboard/ProductDetails.storyboard
@@ -411,19 +411,19 @@
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="ZIP, city" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="Nwp-MQ-iqO">
-                                                                    <rect key="frame" x="0.0" y="26" width="450" height="20"/>
+                                                                    <rect key="frame" x="0.0" y="26" width="450" height="21"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <color key="textColor" red="0.20784313725490194" green="0.24313725490196078" blue="0.28235294117647058" alpha="1" colorSpace="calibratedRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Mo. - Fr. 10.00am - 8..00pm" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="cPb-jC-wJq">
-                                                                    <rect key="frame" x="0.0" y="45" width="450" height="21"/>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Mo. - Fr. 10.00am - 8..00pm" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="cPb-jC-wJq">
+                                                                    <rect key="frame" x="0.0" y="46" width="450" height="21"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <color key="textColor" red="0.20784313725490194" green="0.24313725490196078" blue="0.28235294117647058" alpha="1" colorSpace="calibratedRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Sa. 9.00a.m - 6.00pm" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="NpR-3u-tsi">
-                                                                    <rect key="frame" x="0.0" y="66" width="450" height="21"/>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="NpR-3u-tsi">
+                                                                    <rect key="frame" x="0.0" y="67" width="450" height="20"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <color key="textColor" red="0.20784313725490194" green="0.24313725490196078" blue="0.28235294117647058" alpha="1" colorSpace="calibratedRGB"/>
                                                                     <nil key="highlightedColor"/>

--- a/Sunrise/ViewControllers/ReservationViewController.swift
+++ b/Sunrise/ViewControllers/ReservationViewController.swift
@@ -77,7 +77,6 @@ class ReservationViewController: UIViewController {
         streetAndNumberLabel.text = viewModel.streetAndNumberInfo
         zipAndCityLabel.text = viewModel.zipAndCityInfo
         openLine1Label.text = viewModel.openLine1Info
-        openLine2Label.text = viewModel.openLine2Info
     }
 
 }

--- a/Sunrise/ViewControllers/StoreSelectionViewController.swift
+++ b/Sunrise/ViewControllers/StoreSelectionViewController.swift
@@ -121,8 +121,7 @@ class StoreSelectionViewController: UITableViewController {
             let cell = tableView.dequeueReusableCellWithIdentifier("StoreInfoCell") as! StoreInfoCell
             cell.streetAndNumberLabel.text = viewModel.streetAndNumberInfo
             cell.zipAndCityLabel.text = viewModel.zipAndCityInfo
-            cell.openLine1Label.text = viewModel.openLine1Info
-            cell.openLine2Label.text = viewModel.openLine2Info
+            cell.openLine1Label.text = viewModel.openingTimes
 
             return cell
 

--- a/Sunrise/ViewModels/ReservationViewModel.swift
+++ b/Sunrise/ViewModels/ReservationViewModel.swift
@@ -22,7 +22,6 @@ class ReservationViewModel {
     let streetAndNumberInfo: String?
     let zipAndCityInfo: String?
     let openLine1Info: String?
-    let openLine2Info: String?
 
     private let order: Order
     private let geocoder = CLGeocoder()
@@ -51,8 +50,7 @@ class ReservationViewModel {
         storeName = order.lineItems?.first?.distributionChannel?.name?.localizedString
         streetAndNumberInfo = order.lineItems?.first?.distributionChannel?.streetAndNumberInfo
         zipAndCityInfo = order.lineItems?.first?.distributionChannel?.zipAndCityInfo
-        openLine1Info = order.lineItems?.first?.distributionChannel?.openLine1Info
-        openLine2Info = order.lineItems?.first?.distributionChannel?.openLine2Info
+        openLine1Info = order.lineItems?.first?.distributionChannel?.openingTimes
 
         geocodeStoreAddress()
     }

--- a/Sunrise/ViewModels/StoreSelectionViewModel.swift
+++ b/Sunrise/ViewModels/StoreSelectionViewModel.swift
@@ -167,8 +167,9 @@ class StoreSelectionViewModel: BaseViewModel {
     func storeDistanceAtIndexPath(indexPath: NSIndexPath) -> String {
         let channel = channels[rowForChannelAtIndexPath(indexPath)]
 
-        if let userLocation = userLocation.value, lat = channel.details?.latitude, lon = channel.details?.longitude {
-            let channelLocation = CLLocation(latitude: lat, longitude: lon)
+        if let userLocation = userLocation.value, lat = channel.details?.latitude, lon = channel.details?.longitude,
+                latitude = Double(lat), longitude = Double(lon) {
+            let channelLocation = CLLocation(latitude: latitude, longitude: longitude)
             let distance = userLocation.distanceFromLocation(channelLocation)
             return String(format: "%.1f", arguments: [distance / 1000]) + " km"
         }

--- a/Sunrise/ViewModels/StoreSelectionViewModel.swift
+++ b/Sunrise/ViewModels/StoreSelectionViewModel.swift
@@ -34,12 +34,8 @@ class StoreSelectionViewModel: BaseViewModel {
         return expandedChannel?.zipAndCityInfo
     }
 
-    var openLine1Info: String? {
-        return expandedChannel?.openLine1Info
-    }
-
-    var openLine2Info: String? {
-        return expandedChannel?.openLine2Info
+    var openingTimes: String? {
+        return expandedChannel?.openingTimes
     }
 
     private var productVariantPrice: String {
@@ -79,11 +75,6 @@ class StoreSelectionViewModel: BaseViewModel {
     private var currentVariant: ProductVariant? {
         return product.allVariants.filter({ $0.sku == sku }).first
     }
-
-    private let geocoder = CLGeocoder()
-    private var geocodeRequestsTimer: NSTimer?
-    private var channelLocations = [Channel: CLLocation]()
-    private var processedChannels = Set<Channel>()
 
     private let product: ProductProjection
     private let sku: String
@@ -176,7 +167,8 @@ class StoreSelectionViewModel: BaseViewModel {
     func storeDistanceAtIndexPath(indexPath: NSIndexPath) -> String {
         let channel = channels[rowForChannelAtIndexPath(indexPath)]
 
-        if let userLocation = userLocation.value, channelLocation = channelLocations[channel] {
+        if let userLocation = userLocation.value, lat = channel.details?.latitude, lon = channel.details?.longitude {
+            let channelLocation = CLLocation(latitude: lat, longitude: lon)
             let distance = userLocation.distanceFromLocation(channelLocation)
             return String(format: "%.1f", arguments: [distance / 1000]) + " km"
         }
@@ -244,39 +236,6 @@ class StoreSelectionViewModel: BaseViewModel {
             return NSIndexPath(forRow: channelRow, inSection: 0)
         }
         return nil
-    }
-
-    private func retrieveStoreLocations() {
-        // We need to deplay each geocoding request due to service limitation
-        dispatch_async(dispatch_get_main_queue()) { [unowned self] in
-            self.geocodeRequestsTimer?.invalidate()
-            self.geocodeRequestsTimer = NSTimer.scheduledTimerWithTimeInterval(0.5, target: self, selector: #selector(self.requestStoreLocation), userInfo: nil, repeats: true)
-        }
-    }
-
-    @objc private func requestStoreLocation() {
-        if processedChannels.count == channels.count {
-            geocodeRequestsTimer?.invalidate()
-        } else {
-            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
-                var channelsForProcessing = Set(self.channels)
-                channelsForProcessing.subtractInPlace(self.processedChannels)
-                if let channel = channelsForProcessing.first {
-                    if let zip = channel.address?.postalCode, city = channel.address?.city, street = channel.address?.streetName,
-                    number = channel.address?.streetNumber, country = channel.address?.country {
-                        self.geocoder.geocodeAddressString("\(number) \(street) \(zip) \(city) \(country)", completionHandler: { placemarks, error in
-                            if let location = placemarks?.first?.location {
-                                self.channelLocations[channel] = location
-                                if let indexPath = self.indexPathForChannel(channel) where error == nil {
-                                    self.contentChangesObserver.sendNext(Changeset(modifications: [indexPath]))
-                                }
-                            }
-                        })
-                    }
-                    self.processedChannels.insert(channel)
-                }
-            }
-        }
     }
 
     // MARK: - Creating a reservation
@@ -348,7 +307,6 @@ class StoreSelectionViewModel: BaseViewModel {
             if let results = result.response?["results"] as? [[String: AnyObject]],
             channels = Mapper<Channel>().mapArray(results) where result.isSuccess {
                 self.channels = channels
-                self.retrieveStoreLocations()
 
             } else if let errors = result.errors where result.isFailure {
                 super.alertMessageObserver.sendNext(self.alertMessageForErrors(errors))

--- a/SunriseTests/TestData/reservation.json
+++ b/SunriseTests/TestData/reservation.json
@@ -223,8 +223,10 @@
                  "id":"2f652ada-491d-4af3-bf74-f61a7ce1722d"
                  },
                  "fields":{
-                 "openLine2":"Sa. 9:00AM - 6:00PM",
-                 "openLine1":"Mo-Fr. 10:00AM - 8:00PM",
+                 "openingTimes":{
+                   "en": "Mo-Fr. 10:00AM - 8:00PM\nSa. 9:00AM - 6:00PM",
+                   "de": "Mo-Fr. 10:00 - 20:00\nSa. 9:00 - 18:00"
+                 },
                  "imageUrl":"https://commercetools-joyride.s3.amazonaws.com/channels/SUNRISE_berlin.jpg"
                  }
                  },

--- a/SunriseTests/ViewModels/ReservationViewModelSpec.swift
+++ b/SunriseTests/ViewModels/ReservationViewModelSpec.swift
@@ -48,11 +48,7 @@ class ReservationViewModelSpec: QuickSpec {
             }
 
             it("has the proper opening hours line 1") {
-                expect(reservationViewModel.openLine1Info).to(equal("Mo-Fr. 10:00AM - 8:00PM"))
-            }
-
-            it("has the proper opening hours line 2") {
-                expect(reservationViewModel.openLine2Info).to(equal("Sa. 9:00AM - 6:00PM"))
+                expect(reservationViewModel.openLine1Info).to(equal("Mo-Fr. 10:00AM - 8:00PM\nSa. 9:00AM - 6:00PM"))
             }
 
             it("has the proper product image URL") {


### PR DESCRIPTION
I'm going to publish internal TestFlight once the new custom type and data are imported into either Sunrise Staging or Prod projects.

The only place I've left two separate `UILabel`s for opening items is in the storyboard, in case we start specifying lines separately again. @cneijenhuis - if you think that will never be the case again, I can remove it completely?
