### PR TITLE
Closes #31 Properly show cart discounts

### DIFF
--- a/Sunrise/ViewModels/CartViewModel.swift
+++ b/Sunrise/ViewModels/CartViewModel.swift
@@ -96,17 +96,21 @@ class CartViewModel: BaseViewModel {
     }
 
     func lineItemOldPriceAtIndexPath(indexPath: NSIndexPath) -> String {
-        guard let price = cart.value?.lineItems?[indexPath.row].price, value = price.value,
-        _ = price.discounted?.value else { return "" }
+        guard let lineItem = cart.value?.lineItems?[indexPath.row], price = lineItem.price, value = price.value where
+                price.discounted?.value != nil || (lineItem.discountedPricePerQuantity?.count ?? 0) > 0  else { return "" }
 
         return value.description
     }
 
     func lineItemPriceAtIndexPath(indexPath: NSIndexPath) -> String {
-        guard let price = cart.value?.lineItems?[indexPath.row].price, value = price.value else { return "" }
+        guard let lineItem = cart.value?.lineItems?[indexPath.row], price = lineItem.price, value = price.value else { return "" }
 
         if let discounted = price.discounted?.value {
             return discounted.description
+
+        } else if let discounted = lineItem.discountedPricePerQuantity?.first?.discountedPrice?.value {
+            return discounted.description
+
         } else {
             return value.description
         }

--- a/SunriseTests/TestData/cart.json
+++ b/SunriseTests/TestData/cart.json
@@ -417,7 +417,27 @@
         "id": "c9320e4a-c9a9-4793-add1-64b6693d6cda"
       },
       "quantity": 1,
-      "discountedPricePerQuantity": [],
+      "discountedPricePerQuantity":[{
+        "quantity": 1,
+        "discountedPrice": {
+          "value": {
+            "currencyCode": "EUR",
+            "centAmount": 12750
+          },
+          "includedDiscounts": [
+            {
+              "discount": {
+                "typeId": "cart-discount",
+                "id": "c5592074-8027-479f-bc60-8d90bffe0165"
+              },
+              "discountedAmount": {
+                "currencyCode": "EUR",
+                "centAmount": 1000
+              }
+            }
+          ]
+        }
+      }],
       "supplyChannel": {
         "typeId": "channel",
         "id": "0cb2aed0-ed4f-4c0c-bc66-479ee3b53f5e"

--- a/SunriseTests/ViewModels/CartViewModelSpec.swift
+++ b/SunriseTests/ViewModels/CartViewModelSpec.swift
@@ -32,7 +32,7 @@ class CartViewModelSpec: QuickSpec {
                 expect(cartViewModel.numberOfItems.value).to(equal("3"))
             }
 
-            context("retrieving data for the first cell") {
+            context("retrieving data for the first line item") {
                 let indexPath = NSIndexPath(forRow: 0, inSection: 0)
 
                 it("product name is properly extracted") {
@@ -64,7 +64,7 @@ class CartViewModelSpec: QuickSpec {
                 }
             }
 
-            context("retrieving data for the second cell") {
+            context("retrieving data for the second line item") {
                 let indexPath = NSIndexPath(forRow: 1, inSection: 0)
 
                 it("product name is properly extracted") {
@@ -89,6 +89,10 @@ class CartViewModelSpec: QuickSpec {
 
                 it("has correct quantity") {
                     expect(cartViewModel.lineItemQuantityAtIndexPath(indexPath)).to(equal("1"))
+                }
+                
+                it("has correct discounted price extracted from first discountedPricePerQuantity element") {
+                    expect(cartViewModel.lineItemOldPriceAtIndexPath(indexPath)).to(equal("€127.50"))
                 }
 
                 it("has correct total item price") {

--- a/SunriseTests/ViewModels/ProductViewModelSpec.swift
+++ b/SunriseTests/ViewModels/ProductViewModelSpec.swift
@@ -65,7 +65,7 @@ class ProductViewModelSpec: QuickSpec {
                     }
                     waitUntil { done in
                         productViewModel.activeAttributes.producer
-                        .startWithNext({ [weak self] activeAttributes in
+                        .startWithNext({ activeAttributes in
                             if activeAttributes["size"] == "38" {
                                 expect(productViewModel.sku.value).to(equal("M0E20000000E7W9"))
                                 done()


### PR DESCRIPTION
Change introduced with this PR is related to line items which have `discountedPricePerQuantity`. After merging, we will also show old (strikethroughed) price, and the actual (total price). The old price is retrieved from the first element of the `discountedPricePerQuantity` array (to be more precise `value` of `discountedPrice`).
