### PR TITLE
Closes #127 Watch Improvements

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ platform :ios, '10.0'
 use_frameworks!
 
 def common_pods
-  pod 'Commercetools'
+  pod 'Commercetools', :git => 'http://github.com/commercetools/commercetools-ios-sdk.git', :branch => 'watch-connectivity-improvements'
   pod 'ReactiveCocoa'
   pod 'ReactiveObjC'
   pod 'DZNEmptyDataSet'
@@ -23,7 +23,7 @@ end
 
 target 'Sunrise Watch Extension' do
   platform :watchos, '3.0'
-  pod 'Commercetools'
+  pod 'Commercetools', :git => 'http://github.com/commercetools/commercetools-ios-sdk.git', :branch => 'watch-connectivity-improvements'
   pod 'ReactiveSwift'
   pod 'SDWebImage', '4.0.0-beta2'
   pod 'NKWatchActivityIndicator'

--- a/Sunrise Watch Extension/InterfaceControllers/ReservationsInterfaceController.swift
+++ b/Sunrise Watch Extension/InterfaceControllers/ReservationsInterfaceController.swift
@@ -28,7 +28,8 @@ class ReservationsInterfaceController: WKInterfaceController {
 
     override func awake(withContext context: Any?) {
         super.awake(withContext: context)
-        
+
+        NotificationCenter.default.addObserver(self, selector: #selector(didBecomeActive), name: .NSExtensionHostDidBecomeActive, object: nil)
         activityAnimation = NKWActivityIndicatorAnimation(type: .twoDotsAnimation, controller: self, images: [leftLoadingDot, rightLoadingDot])
         
         [signInGroup, reservationsGroup].forEach { $0.setAlpha(0) }
@@ -36,7 +37,7 @@ class ReservationsInterfaceController: WKInterfaceController {
         
         interfaceModel = ReservationsInterfaceModel.sharedInstance
     }
-    
+
     override func contextForSegue(withIdentifier segueIdentifier: String, in table: WKInterfaceTable, rowIndex: Int) -> Any? {
         return interfaceModel?.reservationDetailsInterfaceModel(for: rowIndex)
     }
@@ -105,5 +106,9 @@ class ReservationsInterfaceController: WKInterfaceController {
                 }
             }
         })
+    }
+
+    @objc private func didBecomeActive() {
+        interfaceModel?.refreshObserver.send(value: ())
     }
 }

--- a/Sunrise Watch Extension/InterfaceModels/ReservationsInterfaceModel.swift
+++ b/Sunrise Watch Extension/InterfaceModels/ReservationsInterfaceModel.swift
@@ -11,6 +11,9 @@ class ReservationsInterfaceModel {
 
     static let sharedInstance = ReservationsInterfaceModel()
 
+    // Inputs
+    let refreshObserver: Observer<Void, NoError>
+
     // Outputs
     let isLoading: MutableProperty<Bool>
     let presentSignInMessage: MutableProperty<Bool>
@@ -26,9 +29,13 @@ class ReservationsInterfaceModel {
         presentSignInMessage = MutableProperty(Commercetools.authState != .customerToken)
         isLoading = MutableProperty(false)
         numberOfRows = MutableProperty(0)
+
         let (presentReservationSignal, presentReservationObserver) = Signal<ReservationDetailsInterfaceModel, NoError>.pipe()
         self.presentReservationSignal = presentReservationSignal
         self.presentReservationObserver = presentReservationObserver
+
+        let (refreshSignal, refreshObserver) = Signal<Void, NoError>.pipe()
+        self.refreshObserver = refreshObserver
         
         NotificationCenter.default.addObserver(self, selector: #selector(checkAuthState), name: Commercetools.Notification.Name.WatchSynchronization.DidReceiveTokens, object: nil)
 
@@ -37,9 +44,18 @@ class ReservationsInterfaceModel {
             if presentSignIn {
                 self?.numberOfRows.value = 0
             } else {
-                self?.retrieveReservations()
+                if self?.presentSignInMessage.value != true {
+                    self?.isLoading.value = true
+                    self?.retrieveReservations()
+                }
             }
         })
+
+        refreshSignal.observeValues { [weak self] in
+            if self?.presentSignInMessage.value != true && self?.isLoading.value != true {
+                self?.retrieveReservations()
+            }
+        }
     }
 
     deinit {
@@ -99,7 +115,6 @@ class ReservationsInterfaceModel {
 
         ProcessInfo.processInfo.performExpiringActivity(withReason: "Retrieve reservations") { [weak self] expired in
             if !expired {
-                self?.isLoading.value = true
                 Order.query(sort: ["createdAt desc"], expansion: ["lineItems[0].distributionChannel"], result: { [weak self] result in
                     if let orders = result.model?.results, result.isSuccess {
                         let reservations = orders.filter { $0.isReservation == true }


### PR DESCRIPTION
Using `performExpiringActivity` for obtaining the reservations. The request can take a while on the watch, so we want to try and continue this activity even if the user lowers the wrist causing the watch to suspend the app.

Also, reservations refresh has been added when the app becomes active again. Reservations refresh doesn't trigger the loading indicator, because the request can take a while, and it's better to let the user browse through the currently available content, before the data from the response is available.

TestFlight build # 66