### PR TITLE
Support locale based voice search and POP links

### DIFF
--- a/ReservationNotification/Info.plist
+++ b/ReservationNotification/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1</string>
 	<key>CFBundleVersion</key>
-	<string>81</string>
+	<string>82</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/ReservationNotification/Info.plist
+++ b/ReservationNotification/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1</string>
 	<key>CFBundleVersion</key>
-	<string>82</string>
+	<string>83</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/Sunrise Watch Extension/Info.plist
+++ b/Sunrise Watch Extension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1</string>
 	<key>CFBundleVersion</key>
-	<string>81</string>
+	<string>82</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/Sunrise Watch Extension/Info.plist
+++ b/Sunrise Watch Extension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1</string>
 	<key>CFBundleVersion</key>
-	<string>82</string>
+	<string>83</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/Sunrise Watch/Info.plist
+++ b/Sunrise Watch/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1</string>
 	<key>CFBundleVersion</key>
-	<string>81</string>
+	<string>82</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Sunrise Watch/Info.plist
+++ b/Sunrise Watch/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1</string>
 	<key>CFBundleVersion</key>
-	<string>82</string>
+	<string>83</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Sunrise.xcodeproj/project.pbxproj
+++ b/Sunrise.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 		211D1D031DF04C0800DDE3C3 /* ReservationNotificationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReservationNotificationController.swift; sourceTree = "<group>"; };
 		213522E11E15FC7000433174 /* ProductCollectionHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductCollectionHeaderView.swift; sourceTree = "<group>"; };
 		213553371EBB6846007E9A60 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		2135533A1EBB799B007E9A60 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2137FA901DCA776800A38A25 /* Sunrise.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Sunrise.entitlements; sourceTree = "<group>"; };
 		2138467A1E7AAC6700A82C63 /* NewAddressViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewAddressViewController.swift; sourceTree = "<group>"; };
 		2147A3241DFA589A00981A30 /* ProductImageCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductImageCell.swift; sourceTree = "<group>"; };
@@ -1525,6 +1526,7 @@
 			isa = PBXVariantGroup;
 			children = (
 				213553371EBB6846007E9A60 /* de */,
+				2135533A1EBB799B007E9A60 /* Base */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/Sunrise.xcodeproj/project.pbxproj
+++ b/Sunrise.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		211D9DED1DECE49D00167C23 /* Money.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE0E296C4DD7568F84DAE /* Money.swift */; };
 		211D9DEE1DECE57B00167C23 /* Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE9B158BE86C70C9F1F47 /* Common.swift */; };
 		213522E21E15FC7000433174 /* ProductCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213522E11E15FC7000433174 /* ProductCollectionHeaderView.swift */; };
+		213553331EBB681F007E9A60 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 213553351EBB681F007E9A60 /* Localizable.strings */; };
 		2138467B1E7AAC6700A82C63 /* NewAddressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2138467A1E7AAC6700A82C63 /* NewAddressViewController.swift */; };
 		2147A3251DFA589A00981A30 /* ProductImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2147A3241DFA589A00981A30 /* ProductImageCell.swift */; };
 		2158A26C1DEA77CC0039E21F /* CommercetoolsProdConfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = 21A8EEAC1CEC69BA009A8CEB /* CommercetoolsProdConfig.plist */; };
@@ -281,6 +282,7 @@
 		211468B51D2088440011A944 /* Cart.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Cart.storyboard; sourceTree = "<group>"; };
 		211D1D031DF04C0800DDE3C3 /* ReservationNotificationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReservationNotificationController.swift; sourceTree = "<group>"; };
 		213522E11E15FC7000433174 /* ProductCollectionHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductCollectionHeaderView.swift; sourceTree = "<group>"; };
+		213553371EBB6846007E9A60 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2137FA901DCA776800A38A25 /* Sunrise.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Sunrise.entitlements; sourceTree = "<group>"; };
 		2138467A1E7AAC6700A82C63 /* NewAddressViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewAddressViewController.swift; sourceTree = "<group>"; };
 		2147A3241DFA589A00981A30 /* ProductImageCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductImageCell.swift; sourceTree = "<group>"; };
@@ -727,6 +729,7 @@
 				21A8EEAA1CEC69AF009A8CEB /* CommercetoolsStagingConfig.plist */,
 				21A8EEAC1CEC69BA009A8CEB /* CommercetoolsProdConfig.plist */,
 				21A9E70B1D65FB1B00AC3953 /* Bridging-Header.h */,
+				213553351EBB681F007E9A60 /* Localizable.strings */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -1060,6 +1063,7 @@
 			knownRegions = (
 				en,
 				Base,
+				de,
 			);
 			mainGroup = 21CDC48B1CE91D9B009D2638;
 			productRefGroup = 21CDC4951CE91D9B009D2638 /* Products */;
@@ -1111,6 +1115,7 @@
 			files = (
 				21A0497E1E4610DC00E476CE /* Categories.storyboard in Resources */,
 				211468B41D1F54240011A944 /* OrdersHeaderView.xib in Resources */,
+				213553331EBB681F007E9A60 /* Localizable.strings in Resources */,
 				211468B61D2088440011A944 /* Cart.storyboard in Resources */,
 				216153A11D1AA03B006C9627 /* Main.storyboard in Resources */,
 				21CDC4A11CE91D9B009D2638 /* Assets.xcassets in Resources */,
@@ -1516,6 +1521,14 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		213553351EBB681F007E9A60 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				213553371EBB6846007E9A60 /* de */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
 		2163EBB31DE8C26C00803640 /* Interface.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -2217,6 +2230,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -2317,6 +2331,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -2411,6 +2426,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -2461,6 +2477,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";

--- a/Sunrise/AppDelegate.swift
+++ b/Sunrise/AppDelegate.swift
@@ -52,9 +52,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if userActivity.activityType == NSUserActivityTypeBrowsingWeb, let url = userActivity.webpageURL {
             let pathComponents = url.pathComponents
             // POP (e.g https://demo.commercetools.com/en/search?q=jeans)
-            if pathComponents.contains("search"), let urlComponents = URLComponents(string: url.absoluteString),
-               let query = urlComponents.queryItems {
-                AppRouting.switchToSearch(query: query["q"] ?? "")
+            if let indexOfSearch = pathComponents.index(of: "search"), let urlComponents = URLComponents(string: url.absoluteString),
+               let query = urlComponents.queryItems, indexOfSearch > 0 {
+                AppRouting.switchToSearch(query: query["q"] ?? "", locale: Locale(identifier: pathComponents[indexOfSearch - 1]))
                 return true
 
             // PDP (e.g https://demo.commercetools.com/en/brunello-cucinelli-coat-mf9284762-cream-M0E20000000DQR5.html)

--- a/Sunrise/Helpers/AppRouting.swift
+++ b/Sunrise/Helpers/AppRouting.swift
@@ -110,9 +110,9 @@ class AppRouting {
 
         - parameter query:                   Optional parameter, if specified, used for populating the search field.
     */
-    static func switchToSearch(query: String = "", becomeFirstResponder: Bool = false) {
+    static func switchToSearch(query: String = "", locale: Locale = Locale.current, becomeFirstResponder: Bool = false) {
         switchToHome()
-        productOverviewViewController?.searchController.searchBar.text = query
+        productOverviewViewController?.viewModel?.textSearch.value = (query, locale)
         if becomeFirstResponder {
             DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.05) {
                 productOverviewViewController?.searchController.searchBar.becomeFirstResponder()

--- a/Sunrise/Info.plist
+++ b/Sunrise/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>81</string>
+	<string>82</string>
 	<key>Displayable attributes</key>
 	<array>
 		<string>colorFreeDefinition</string>

--- a/Sunrise/Info.plist
+++ b/Sunrise/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>82</string>
+	<string>83</string>
 	<key>Displayable attributes</key>
 	<array>
 		<string>colorFreeDefinition</string>

--- a/Sunrise/ViewControllers/Products/ProductOverviewViewController.swift
+++ b/Sunrise/ViewControllers/Products/ProductOverviewViewController.swift
@@ -72,6 +72,14 @@ class ProductOverviewViewController: UICollectionViewController {
             }
         })
 
+        viewModel.textSearch.producer
+        .observe(on: UIScheduler())
+        .startWithValues({ [weak self] searchText, _ in
+            if searchText != self?.searchController.searchBar.text {
+                self?.searchController.searchBar.text = searchText
+            }
+        })
+
         disposables += viewModel.presentProductDetailsSignal
         .observe(on: UIScheduler()).observeValues { [weak self] product in
             self?.performSegue(withIdentifier: "showProductDetails", sender: product)
@@ -99,6 +107,7 @@ class ProductOverviewViewController: UICollectionViewController {
                 [productHeaderView.headerLabel, productHeaderView.myStoreNameLabel].forEach { $0.isHidden = false }
             }
         })
+
         viewModel.browsingStoreName.producer
         .observe(on: UIScheduler())
         .take(until: productHeaderView.reactive.prepareForReuse)
@@ -210,9 +219,9 @@ class ProductOverviewViewController: UICollectionViewController {
     }
 
     @objc private func performSearch() {
-        if let searchText = searchController.searchBar.text, searchText != viewModel?.searchText.value {
+        if let searchText = searchController.searchBar.text, searchText != viewModel?.textSearch.value.0 {
             SVProgressHUD.show()
-            viewModel?.searchText.value = searchText
+            viewModel?.textSearch.value = (searchText, Locale.current)
         }
     }
 

--- a/Sunrise/ViewModels/Products/VoiceSearchViewModel.swift
+++ b/Sunrise/ViewModels/Products/VoiceSearchViewModel.swift
@@ -71,9 +71,15 @@ class VoiceSearchViewModel: BaseViewModel {
         
         let audioSession = AVAudioSession.sharedInstance()
 
-        try? audioSession.setCategory(AVAudioSessionCategoryRecord)
-        try? audioSession.setMode(AVAudioSessionModeMeasurement)
-        try? audioSession.setActive(true, with: .notifyOthersOnDeactivation)
+        do {
+            try audioSession.setCategory(AVAudioSessionCategoryRecord)
+            try audioSession.setMode(AVAudioSessionModeMeasurement)
+            try audioSession.setActive(true, with: .notifyOthersOnDeactivation)
+        } catch {
+            alertMessageObserver.send(value: "\(error)")
+            return
+        }
+
 
         inputNode = audioEngine.inputNode
         guard let inputNode = inputNode else {

--- a/Sunrise/ViewModels/Products/VoiceSearchViewModel.swift
+++ b/Sunrise/ViewModels/Products/VoiceSearchViewModel.swift
@@ -67,7 +67,10 @@ class VoiceSearchViewModel: BaseViewModel {
     }
 
     private func recognizeSpeech() {
-        let recognizer = SFSpeechRecognizer(locale: Locale.init(identifier: "en-US"))!
+        guard let recognizer = SFSpeechRecognizer() else {
+            alertMessageObserver.send(value: "Cannot perform speech recognition with your locale")
+            return
+        }
         
         let audioSession = AVAudioSession.sharedInstance()
 

--- a/Sunrise/de.lproj/Localizable.strings
+++ b/Sunrise/de.lproj/Localizable.strings
@@ -1,2 +1,2 @@
 /* Speech summer dress suggestion */
-"Try: \"summer dress\"" = "Probieren: \"sommerkleider\"";
+"Try: \"summer dress\"" = "Probieren Sie: \"Sommerkleider\"";

--- a/Sunrise/de.lproj/Localizable.strings
+++ b/Sunrise/de.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+/* Speech summer dress suggestion */
+"Try: \"summer dress\"" = "Probieren: \"sommerkleider\"";


### PR DESCRIPTION
These changes are included in the TestFlight build # 83:
- The speech recognition works using the locale from the user's device. In addition to this, I've added German locale for the app, and provided translation for the hint we display to the user when using the voice search feature. It was necessary to do this now - it's the only way for the user to know in which language to speak ☺️ 
- POP search links can be in different locale, and we now support proper link handling (e.g when performing the search for _https://demo.commercetools.com/en/search?q=jeans_ we'll set the language to "en" and look for text "jeans", while _https://demo.commercetools.com/de/search?q=jeans_ would set the language property to "de").