### PR TITLE
Configurable categories root, expiration time

### DIFF
--- a/ReservationNotification/Info.plist
+++ b/ReservationNotification/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1</string>
 	<key>CFBundleVersion</key>
-	<string>90</string>
+	<string>92</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/Sunrise Watch Extension/Info.plist
+++ b/Sunrise Watch Extension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1</string>
 	<key>CFBundleVersion</key>
-	<string>90</string>
+	<string>92</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/Sunrise Watch/Info.plist
+++ b/Sunrise Watch/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1</string>
 	<key>CFBundleVersion</key>
-	<string>90</string>
+	<string>92</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Sunrise/Info.plist
+++ b/Sunrise/Info.plist
@@ -30,7 +30,9 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>90</string>
+	<string>92</string>
+	<key>Category cache expiration</key>
+	<integer>3600</integer>
 	<key>Displayable attributes</key>
 	<array>
 		<string>colorFreeDefinition</string>

--- a/Sunrise/ViewControllers/Categories/CategoriesViewController.swift
+++ b/Sunrise/ViewControllers/Categories/CategoriesViewController.swift
@@ -45,6 +45,7 @@ class CategoriesViewController: UIViewController {
         super.viewWillAppear(animated)
 
         navigationItem.title = viewModel?.title
+        viewModel?.refreshObserver.send(value: ())
     }
 
     func bindViewModel() {


### PR DESCRIPTION
In this PR, we have introduced two parameters, which can be included in the `Info.plist` file:

- Category cache expiry time:
```
<key>Category cache expiration</key>
<integer>3600</integer>
```

- Navigation external ID:
```
<key>Navigation external ID</key>
<string>some-ext-id</string>
```

The TestFlight build # 92 contains these changes. At this point, only cache expiration is set to one hour. @mmoelli do we want to set some navigation external ID as a root one, for the tree we're showing in the app for the Sunrise project?