### PR TITLE
Closes #178 Remove legacy hostnames

### DIFF
--- a/Sunrise/CommercetoolsProdConfig.plist
+++ b/Sunrise/CommercetoolsProdConfig.plist
@@ -11,9 +11,9 @@
         <key>clientSecret</key>
         <string>Nx4ZwW3dNZJreGhtW8KjM5hi1FtHlw4e</string>
         <key>authUrl</key>
-        <string>https://auth.sphere.io</string>
+        <string>https://auth.europe-west1.gcp.commercetools.com</string>
         <key>apiUrl</key>
-        <string>https://api.sphere.io</string>
+        <string>https://api.europe-west1.gcp.commercetools.com</string>
         <key>anonymousSession</key>
         <true/>
         <key>keychainAccessGroupName</key>

--- a/Sunrise/CommercetoolsStagingConfig.plist
+++ b/Sunrise/CommercetoolsStagingConfig.plist
@@ -11,9 +11,9 @@
         <key>clientSecret</key>
         <string>7Qm1SFxirhxXtAfKI5nRX70zmBDnPDLL</string>
         <key>authUrl</key>
-        <string>https://auth.sphere.io</string>
+        <string>https://auth.europe-west1.gcp.commercetools.com</string>
         <key>apiUrl</key>
-        <string>https://api.sphere.io</string>
+        <string>https://api.europe-west1.gcp.commercetools.com</string>
         <key>anonymousSession</key>
         <true/>
     </dict>


### PR DESCRIPTION
Changes are minimal, since the Sunrise iOS project was only using `*.sphere.io` references.